### PR TITLE
Rewrite Deck

### DIFF
--- a/com.foss.llamas.poker/lib/src/main/java/com/foss/llamas/poker/domain/Deck.java
+++ b/com.foss.llamas.poker/lib/src/main/java/com/foss/llamas/poker/domain/Deck.java
@@ -1,38 +1,46 @@
 package com.foss.llamas.poker.domain;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
+/// A deck to draw cards from.
 public class Deck {
-	private List<Card> originalCards;
 	private List<Card> cards;
-	public Deck(List<Card> cards) {
-		this.cards = cards;
-		this.originalCards = new ArrayList<>(originalCards);
+	private int cardsDrawn;
+	// TODO: Default constructor for a 52 card deck.
+	public Deck(Collection<Card> cards) {
+		this.cards = new ArrayList<>(cards);
+		cardsDrawn = 0;
 		shuffle();
 	}
 	
 	public void refresh() {
-		cards.clear();
-		cards.addAll(originalCards);
+		this.cardsDrawn = 0;
 		shuffle();
 	}
 	
-	public void shuffle() {
+	private void shuffle() {
 		Collections.shuffle(cards);
 	}
 	
-	public int getRemainingCardCount() {
-		return cards.size();
+	public int getCardsDrawn() {
+		return this.cardsDrawn;
 	}
 	
-	public Card draw() throws UnsupportedOperationException {
-		if (!cards.isEmpty()) {
-			return cards.remove(0);
-		}
-		else {
-			throw new UnsupportedOperationException("Deck is out of cards.");
+	public int getCardsRemaining() {
+		return this.cards.size() - this.cardsDrawn;
+	}
+	
+	public Optional<Card> draw() {
+		if (this.getCardsRemaining() == 0) {
+			return Optional.empty();
+		} else {
+			final var index = this.cardsDrawn;
+			++this.cardsDrawn;
+			return Optional.of(this.cards.get(index));
 		}
 	}
 }


### PR DESCRIPTION
This commit includes a rewritten version of the Deck class.

* `draw` fails a bit more softly.
* The type required by the constructor is now a `Collection`, the most general type that Java ArrayLists permit in normal construction.
* Internals are a bit different. Instead of maintaining a reference to the initial collection (which may be mutated, which may be an unexpected feature) and refilling the deck from that on `refresh`, instead there's one list that is traversed using an integer counter. The main downside is that this complicates the late addition of cards into the deck (and shuffling), but some hacks using sublists may be possible.
* Tweaked some names.