### PR TITLE
Add JetBrains to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+
+.idea


### PR DESCRIPTION
Adds `.idea` to the `.gitignore` file for JetBrains IDE users.