### PR TITLE
Fix package location for HandEvaluatorTest.java

### DIFF
--- a/com.foss.llamas.poker/lib/src/test/java/com/foss/llamas/poker/domain/HandEvaluatorTest.java
+++ b/com.foss.llamas.poker/lib/src/test/java/com/foss/llamas/poker/domain/HandEvaluatorTest.java
@@ -1,4 +1,4 @@
-package com.foss.llamas.poker;
+package com.foss.llamas.poker.domain;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
There is a compile error where the folder structure does not match the package for HandEvaluatorTest.java.

This fixes the issue.