### PR TITLE
Add 'ante' Command

### DIFF
--- a/com.foss.llamas.poker/lib/src/main/java/com/foss/llamas/poker/domain/commands/AnteCommand.java
+++ b/com.foss.llamas.poker/lib/src/main/java/com/foss/llamas/poker/domain/commands/AnteCommand.java
@@ -1,0 +1,17 @@
+package com.foss.llamas.poker.domain.commands;
+
+import com.beust.jcommander.Parameters;
+import com.beust.jcommander.ParametersDelegate;
+
+@Parameters(commandNames = AnteCommand.COMMAND_NAME, separators = "=")
+public class AnteCommand {
+	public static final String COMMAND_NAME = "ante";
+
+	@ParametersDelegate
+	private CommandDelegate delegate = new CommandDelegate();
+
+	public CommandDelegate getDelegate() {
+		return delegate;
+	}
+	
+}

--- a/com.foss.llamas.poker/lib/src/main/java/com/foss/llamas/poker/domain/commands/AnteCommand.java
+++ b/com.foss.llamas.poker/lib/src/main/java/com/foss/llamas/poker/domain/commands/AnteCommand.java
@@ -1,17 +1,25 @@
 package com.foss.llamas.poker.domain.commands;
 
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 
 @Parameters(commandNames = AnteCommand.COMMAND_NAME, separators = "=")
 public class AnteCommand {
 	public static final String COMMAND_NAME = "ante";
+	
+	@Parameter(names = "--required", description = "Is the ante required to view the hole cards?")
+	private boolean required = false;
 
 	@ParametersDelegate
 	private CommandDelegate delegate = new CommandDelegate();
 
 	public CommandDelegate getDelegate() {
 		return delegate;
+	}
+	
+	public final boolean isRequired() {
+		return required;
 	}
 	
 }


### PR DESCRIPTION
The 'ante' command is for games in which there is an ante initiated, that all players who receive their two hole cards must match to play, or fold. In some variations of the rules, the players cannot see their hole cards unless they pay the ante.