### PR TITLE
Deck refactor with tests

### DIFF
--- a/com.foss.llamas.poker/lib/src/main/java/com/foss/llamas/poker/domain/Deck.java
+++ b/com.foss.llamas.poker/lib/src/main/java/com/foss/llamas/poker/domain/Deck.java
@@ -1,25 +1,26 @@
 package com.foss.llamas.poker.domain;
 
-import java.util.ArrayList;
+import java.util.Stack;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 /// A deck to draw cards from.
 public class Deck implements DeckInterface {
-	private List<Card> cards;
-	private int cardsDrawn;
-	// TODO: Default constructor for a 52 card deck.
+	private final Stack<Card> cards;
+	private final Stack<Card> drawnCards;
+
 	public Deck(Collection<Card> cards) {
-		this.cards = new ArrayList<>(cards);
-		cardsDrawn = 0;
+		this.cards = new Stack<>();
+		this.drawnCards = new Stack<>();
+		this.cards.addAll(cards);
 		shuffle();
 	}
 	
 	@Override
 	public void refresh() {
-		this.cardsDrawn = 0;
+		this.cards.addAll(drawnCards);
+		this.drawnCards.clear();
 		shuffle();
 	}
 	
@@ -29,12 +30,12 @@ public class Deck implements DeckInterface {
 	
 	@Override
 	public int getCardsDrawn() {
-		return this.cardsDrawn;
+		return this.drawnCards.size();
 	}
 	
 	@Override
 	public int getCardsRemaining() {
-		return this.cards.size() - this.cardsDrawn;
+		return this.cards.size();
 	}
 	
 	@Override
@@ -42,9 +43,9 @@ public class Deck implements DeckInterface {
 		if (this.getCardsRemaining() == 0) {
 			return Optional.empty();
 		} else {
-			final var index = this.cardsDrawn;
-			++this.cardsDrawn;
-			return Optional.of(this.cards.get(index));
+			Card card = this.cards.pop();
+			this.drawnCards.push(card);
+			return Optional.of(card);
 		}
 	}
 }

--- a/com.foss.llamas.poker/lib/src/test/java/com/foss/llamas/poker/domain/DeckTest.java
+++ b/com.foss.llamas.poker/lib/src/test/java/com/foss/llamas/poker/domain/DeckTest.java
@@ -1,0 +1,62 @@
+package com.foss.llamas.poker.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DeckTest {
+	@Test
+	void refresh() {
+		DeckInterface deck = new DeckBuilder().addStandardPokerCards().build();
+		deck.refresh();
+		assertEquals(0, deck.getCardsDrawn());
+		assertEquals(52, deck.getCardsRemaining());
+	}
+
+	@Test
+	void getCardsDrawn() {
+		DeckInterface deck = new DeckBuilder().addStandardPokerCards().build();
+		assertEquals(0, deck.getCardsDrawn());
+		deck.draw();
+		assertEquals(1, deck.getCardsDrawn());
+		for (int i = 0; i < 12; i++) {
+			deck.draw();
+		}
+		assertEquals(13, deck.getCardsDrawn());
+		deck.refresh();
+		assertEquals(0, deck.getCardsDrawn());
+	}
+
+	@Test
+	void getCardsRemaining() {
+		DeckInterface deck = new DeckBuilder().addStandardPokerCards().build();
+		assertEquals(52, deck.getCardsRemaining());
+		deck.draw();
+		assertEquals(51, deck.getCardsRemaining());
+		for (int i = 0; i < 12; i++) {
+			deck.draw();
+		}
+		assertEquals(39, deck.getCardsRemaining());
+		deck.refresh();
+		assertEquals(52, deck.getCardsRemaining());
+	}
+
+	@Test
+	void draw() {
+		DeckInterface deck = new DeckBuilder().addStandardPokerCards().build();
+		Map<String, Boolean> seen = new HashMap<>();
+		for (int i = 0; i < 52; i++) {
+			Optional<Card> card = deck.draw();
+			assertTrue(card.isPresent());
+			String cardString = card.get().getRank().toString() + card.get().getSuit().toString();
+			assertFalse(seen.containsKey(cardString));
+			seen.put(cardString, true);
+		}
+		Optional<Card> card = deck.draw();
+		assertFalse(card.isPresent());
+	}
+}


### PR DESCRIPTION
This refactors `Deck` to use a `Stack`, as a deck of cards is truly a stack which cards are popped from and pushed onto. The popped cards are also placed onto a second `Stack<Card> drawnCards`. The `int` counting logic has been replaced with simple `size()` calls for each stack. Tests for all `Deck` methods as well.