### PR TITLE
`StraightEvaluator` checks from top down; always set top 5

### DIFF
--- a/com.foss.llamas.poker/lib/src/main/java/com/foss/llamas/poker/domain/evaluators/StraightEvaluator.java
+++ b/com.foss.llamas.poker/lib/src/main/java/com/foss/llamas/poker/domain/evaluators/StraightEvaluator.java
@@ -37,8 +37,8 @@ public class StraightEvaluator extends HandResult {
 
 		Multimap<Rank, Integer> rankValueMap = getRankValueMap();
 		// Step 3: Look for straights.
-		for (int startOfStraight = 1; startOfStraight <= 10; startOfStraight++) {
-			int endOfStraight = startOfStraight + 4;
+		for (int endOfStraight = 14; endOfStraight >= 5; endOfStraight--) {
+			int startOfStraight = endOfStraight - 4;
 			
 			Map<Rank, Card> cardsToSet = new LinkedHashMap<>();
 			for (Card card : cardQueue) {
@@ -57,7 +57,8 @@ public class StraightEvaluator extends HandResult {
 				return true;
 			}
 		}
-		
+
+		setCards(new ArrayList<>(collectTopFiveCards(cardQueue, wildCards)));
 		return false;
 	}
 }

--- a/com.foss.llamas.poker/lib/src/test/java/com/foss/llamas/poker/domain/HandEvaluatorTest.java
+++ b/com.foss.llamas.poker/lib/src/test/java/com/foss/llamas/poker/domain/HandEvaluatorTest.java
@@ -6,13 +6,6 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import com.foss.llamas.poker.domain.StandardCard;
-import com.foss.llamas.poker.domain.Card;
-import com.foss.llamas.poker.domain.Color;
-import com.foss.llamas.poker.domain.HandEvaluatorBuilder;
-import com.foss.llamas.poker.domain.HandEvaluatorUtil;
-import com.foss.llamas.poker.domain.Rank;
-import com.foss.llamas.poker.domain.Suit;
 import com.foss.llamas.poker.domain.evaluators.PairEvaluator;
 import com.foss.llamas.poker.domain.evaluators.StraightEvaluator;
 

--- a/com.foss.llamas.poker/lib/src/test/java/com/foss/llamas/poker/domain/HandEvaluatorTest.java
+++ b/com.foss.llamas.poker/lib/src/test/java/com/foss/llamas/poker/domain/HandEvaluatorTest.java
@@ -52,13 +52,15 @@ public class HandEvaluatorTest {
 	@Test 
 	public void testStraight() {
 		List<Card> cards = new ArrayList<>(5);
-		
+		HandResult eval = new StraightEvaluator();
+
 		cards.add(StandardCard.build(Rank.ACE, Suit.CLUBS));
 		cards.add(StandardCard.build(Rank.ACE, Suit.HEARTS));
 		cards.add(StandardCard.build(Rank.THREE, Suit.SPADES));
 		cards.add(StandardCard.build(Rank.FOUR, Suit.CLUBS));
 		cards.add(StandardCard.build(Rank.FIVE, Suit.DIAMONDS));
-		Assertions.assertFalse(new StraightEvaluator().test(cards));
+		Assertions.assertFalse(eval.test(cards));
+		Assertions.assertTrue(doesResultContainCards(eval, cards));
 
 		cards.clear();
 		cards.add(StandardCard.build(Rank.ACE, Suit.CLUBS));
@@ -66,7 +68,8 @@ public class HandEvaluatorTest {
 		cards.add(StandardCard.build(Rank.THREE, Suit.SPADES));
 		cards.add(StandardCard.build(Rank.FOUR, Suit.CLUBS));
 		cards.add(StandardCard.build(Rank.FIVE, Suit.DIAMONDS));
-		Assertions.assertTrue(new StraightEvaluator().test(cards));
+		Assertions.assertTrue(eval.test(cards));
+		Assertions.assertTrue(doesResultContainCards(eval, cards));
 
 		cards.clear();
 		cards.add(StandardCard.build(Rank.TEN, Suit.DIAMONDS));
@@ -74,7 +77,8 @@ public class HandEvaluatorTest {
 		cards.add(StandardCard.build(Rank.QUEEN, Suit.SPADES));
 		cards.add(StandardCard.build(Rank.KING, Suit.CLUBS));
 		cards.add(StandardCard.build(Rank.ACE, Suit.DIAMONDS));
-		Assertions.assertTrue(new StraightEvaluator().test(cards));
+		Assertions.assertTrue(eval.test(cards));
+		Assertions.assertTrue(doesResultContainCards(eval, cards));
 		
 		cards.clear();
 		cards.add(StandardCard.build(Rank.JACK, Suit.CLUBS));
@@ -82,7 +86,8 @@ public class HandEvaluatorTest {
 		cards.add(StandardCard.build(Rank.KING, Suit.SPADES));
 		cards.add(StandardCard.build(Rank.ACE, Suit.CLUBS));
 		cards.add(StandardCard.build(Rank.TWO, Suit.DIAMONDS));
-		Assertions.assertFalse(new StraightEvaluator().test(cards));
+		Assertions.assertFalse(eval.test(cards));
+		Assertions.assertTrue(doesResultContainCards(eval, cards));
 		
 		cards.clear();
 		cards.add(StandardCard.build(Rank.SEVEN, Suit.CLUBS));
@@ -90,7 +95,8 @@ public class HandEvaluatorTest {
 		cards.add(StandardCard.build(Rank.NINE, Suit.SPADES));
 		cards.add(StandardCard.build(Rank.TEN, Suit.CLUBS));
 		cards.add(StandardCard.build(Rank.JACK, Suit.DIAMONDS));
-		Assertions.assertTrue(new StraightEvaluator().test(cards));
+		Assertions.assertTrue(eval.test(cards));
+		Assertions.assertTrue(doesResultContainCards(eval, cards));
 
 		cards.clear();
 		cards.add(StandardCard.build(Rank.JOKER, Suit.JOKER));
@@ -98,6 +104,19 @@ public class HandEvaluatorTest {
 		cards.add(StandardCard.build(Rank.FIVE, Suit.SPADES));
 		cards.add(StandardCard.build(Rank.SIX, Suit.CLUBS));
 		cards.add(StandardCard.build(Rank.SEVEN, Suit.DIAMONDS));
-		Assertions.assertTrue(new StraightEvaluator().test(cards));
+		Assertions.assertTrue(eval.test(cards));
+		Assertions.assertTrue(doesResultContainCards(eval, cards));
+	}
+
+	private boolean doesResultContainCards(HandResult result, List<Card> cards) {
+		for (Card card : cards) {
+			if (card.getRank() == Rank.JOKER) {
+				continue;
+			}
+			if (!result.getCards().contains(card)) {
+				return false;
+			}
+		}
+		return true;
 	}
 }


### PR DESCRIPTION
* `StraightEvaluator` now checks for straights from the top-down, that way the highest straight possible is collected.
* The cards are always set into the `HandResult` — if there is no straight, the top five cards are collected.